### PR TITLE
feat: Button 與 Spinner 元件

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -1,8 +1,35 @@
 import React from "react";
 import "./styles.css";
+import Spinner from "../Spinner";
 
-const Button = ({ children }) => {
-  return <button>{children}</button>;
+const Button = ({
+  className = "",
+  disabled,
+  children,
+  isLoading,
+  onClick,
+  color = "#3b82f6",
+  textColor = "white",
+  width,
+  ...props
+}) => {
+  return (
+    <button
+      className={`button ${className}`}
+      aria-disabled={disabled}
+      disabled={isLoading || disabled}
+      onClick={(e) => onClick?.(e)}
+      style={{
+        "--button-bg": color,
+        "--button-text": textColor,
+        ...(width ? { width: width + "px" } : {}),
+      }}
+      {...props}
+    >
+      {isLoading ? <span className="sr-only">正在載入...</span> : null}
+      {isLoading ? <Spinner color={color} size="sm" /> : children}
+    </button>
+  );
 };
 
 export default Button;

--- a/src/components/Button/Button.stories.jsx
+++ b/src/components/Button/Button.stories.jsx
@@ -1,9 +1,115 @@
 import React from "react";
 import Button from "./Button";
-
+const COLOR_OPTIONS = {
+  "#2563eb": "主要藍",
+  "#16a34a": "成功綠",
+  "#eab308": "警告黃",
+  "#dc2626": "危險紅",
+  "#4f46e5": "靛藍色",
+  "#8b5cf6": "紫羅蘭",
+  "#ec4899": "粉玫瑰",
+  "#4b5563": "深灰色",
+  "#f3f4f6": "淺灰色",
+  "#171717": "純黑色",
+};
+const COLORS = [
+  "#2563eb",
+  "#16a34a",
+  "#eab308",
+  "#dc2626",
+  "#4f46e5",
+  "#8b5cf6",
+  "#ec4899",
+  "#4b5563",
+  "#f3f4f6",
+  "#171717",
+];
+const TEXT_COLOR_OPTIONS = {
+  white: "純白色",
+  "#171717": "純黑色",
+  "#1e40af": "深藍色",
+  "#166534": "深綠色",
+  "#78350f": "深棕色",
+  "#374151": "深灰色",
+};
+const TEXT_COLORS = [
+  "white",
+  "#171717",
+  "#1e40af",
+  "#166534",
+  "#78350f",
+  "#374151",
+];
 export default {
   title: "Components/Button",
   component: Button,
 };
 
-export const Default = () => <Button>Default Button</Button>;
+const Template = (args) => <Button {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  children: "按鈕",
+  color: "#3b82f6",
+  textColor: "white",
+  width: 200,
+};
+Default.argTypes = {
+  color: {
+    options: COLORS,
+    control: {
+      type: "select",
+      labels: COLOR_OPTIONS,
+    },
+    description: "按鈕背景顏色",
+  },
+  textColor: {
+    options: TEXT_COLORS,
+    control: {
+      type: "select",
+      labels: TEXT_COLOR_OPTIONS,
+    },
+    description: "按鈕文字顏色",
+  },
+  children: {
+    control: "text",
+    description: "按鈕文字",
+  },
+  width: { table: { disable: true } },
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  children: "加載中",
+  color: "#3b82f6",
+  textColor: "white",
+  width: 200,
+  isLoading: true,
+};
+Loading.argTypes = {
+  color: {
+    options: COLORS,
+    control: {
+      type: "select",
+      labels: COLOR_OPTIONS,
+    },
+    description: "按鈕背景顏色",
+  },
+  textColor: {
+    options: TEXT_COLORS,
+    control: {
+      type: "select",
+      labels: TEXT_COLOR_OPTIONS,
+    },
+    description: "按鈕文字顏色",
+  },
+  children: {
+    control: "text",
+    description: "按鈕文字",
+  },
+  width: {
+    control: { type: "number" },
+    description: "按鈕寬度 (px)",
+    defaultValue: 200,
+  },
+};

--- a/src/components/Button/styles.css
+++ b/src/components/Button/styles.css
@@ -1,1 +1,44 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  border-radius: 0.375rem;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  background-color: var(--button-bg, #3b82f6);
+  color: var(--button-text, white);
+  --spinner-color: color-mix(in srgb, var(--button-bg, #3b82f6) 80%, black);
+}
 
+.button:hover {
+  background-color: color-mix(in srgb, var(--button-bg, #3b82f6) 90%, black);
+}
+
+.button:disabled {
+  background-color: color-mix(in srgb, var(--button-bg, #3b82f6) 40%, white);
+  cursor: not-allowed;
+}
+
+.button .spinner {
+  margin: 0;
+  color: var(--button-bg, #3b82f6);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/Spinner/Spinner.jsx
+++ b/src/components/Spinner/Spinner.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import "./styles.css";
+
+const Spinner = ({ size = "md", className = "", color, ...props }) => {
+  const darkerColor = color
+    ? `color-mix(in srgb, ${color} 80%, black)`
+    : undefined;
+
+  return (
+    <div
+      className={`spinner ${className}`}
+      role="status"
+      aria-hidden="true"
+      style={{ color: darkerColor }}
+      {...props}
+    >
+      <span className={`spinner-inner spinner-${size}`} />
+    </div>
+  );
+};
+
+export default Spinner;

--- a/src/components/Spinner/Spinner.stories.jsx
+++ b/src/components/Spinner/Spinner.stories.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import Spinner from "./Spinner";
+
+export default {
+  title: "Components/Spinner",
+  component: Spinner,
+};
+
+export const Default = () => <Spinner />;

--- a/src/components/Spinner/index.js
+++ b/src/components/Spinner/index.js
@@ -1,0 +1,3 @@
+import Spinner from "./Spinner";
+
+export default Spinner;

--- a/src/components/Spinner/styles.css
+++ b/src/components/Spinner/styles.css
@@ -1,0 +1,32 @@
+.spinner-inner {
+  display: inline-block;
+  border: 4px solid currentColor;
+  border-radius: 50%;
+  border-right-color: transparent;
+  border-top-color: transparent;
+  animation: spinner-rotate 0.75s linear infinite;
+}
+
+.spinner-sm {
+  width: 1rem;
+  height: 1rem;
+}
+
+.spinner-md {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.spinner-lg {
+  width: 2rem;
+  height: 2rem;
+}
+
+@keyframes spinner-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## 主要內容
- 新增 Button 與 Spinner 元件
- Button 支援自訂背景色、文字色、寬度（loading 狀態下）
- Button loading 狀態下顯示置中 Spinner，Spinner 粗細 4px，預設小尺寸

## Storybook 展示
- Button 正常狀態：可切換顏色、文字顏色、文字
- Button loading 狀態：可切換顏色、文字顏色、寬度、文字
- 控制項僅允許常用顏色與固定寬度

## 測試方式
- 請於 Storybook 切換各種顏色、寬度、狀態，確認元件行為與設計一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the button component with customizable colors, text color, width, loading state, and improved accessibility for screen readers.
  - Introduced a spinner component with configurable size and color, used for indicating loading states.
- **Style**
  - Added new styles for button and spinner components, including hover, disabled, and visually hidden states for accessibility.
- **Documentation**
  - Updated and added Storybook stories for both button and spinner components, with improved controls and localization for easier preview and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->